### PR TITLE
Added code to deal with passwords that never expire.

### DIFF
--- a/ADpassword
+++ b/ADpassword
@@ -115,7 +115,11 @@ if __name__ == '__main__':
         alert="This workstation has not joined a domain"
         vp_start_gui(alert)
     else:
-        days_to_expire=(password_expiration_datetime - datetime.datetime.today()).days
+        if password_expiration_datetime != 'never':
+            days_to_expire=(password_expiration_datetime - datetime.datetime.today()).days
+        else:
+            days_to_expire=42000000
+# Given mean life expectancy 42.000.000 days is pretty close to never
         if (days_to_expire < args.DAYS):  
             alert="Your password will expire in "+ str(days_to_expire)+ " days"
             vp_start_gui(alert)

--- a/adpassword_support.py
+++ b/adpassword_support.py
@@ -46,7 +46,10 @@ def query_user_password_policy(ldap_server,user):
         items=re.search("Password must change Time:\s*(.*)\n", line)
         if items:
             cleardate=items.groups(0)[0]
-            password_expiration_datetime=datetime.datetime.strptime(cleardate, "%a, %d %b %Y %H:%M:%S %Z")
+            if (cleardate == 'never'):
+                password_expiration_datetime=cleardate
+            else:
+                password_expiration_datetime=datetime.datetime.strptime(cleardate, "%a, %d %b %Y %H:%M:%S %Z")
             break
    
     if (cmd.wait() == 0):


### PR DESCRIPTION
adpassword_suppor.py: Checked for "never" answer before parsing datetime. Return "never" if thats the answer.
ADpassword: Avoid calculation of days left before change in case the answer is never, instead use a value of 42000000 (arbitrarily close to never).
